### PR TITLE
Stash `.toString()` in prototype

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,16 +223,16 @@ module.exports = function loader(content) {
       const images = files.map(f => '{path:' + f.path + ',width:' + f.width + ',height:' + f.height + '}').join(',');
 
       const firstImage = files[0];
-
-      loaderCallback(null, 'module.exports = {' +
+      // prevent toString from injected into {...img} or JSON.stringify
+      // Object.assign is to avoid verbose syntax in Object.create; __proto__ is shorter but deprecated
+      loaderCallback(null, 'module.exports = Object.assign(Object.create({toString(){return this.src;}}),{' +
           'srcSet:' + srcset + ',' +
           'images:[' + images + '],' +
           'src:' + firstImage.path + ',' +
-          'toString:function(){return ' + firstImage.path + '},' +
           'placeholder: ' + placeholder + ',' +
           'width:' + firstImage.width + ',' +
-          'height:' + firstImage.height +
-      '};');
+          'height:' + firstImage.height + ',' +
+          '});');
     })
     .catch(err => loaderCallback(err));
 };

--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,7 @@ module.exports = function loader(content) {
           'src:' + firstImage.path + ',' +
           'placeholder: ' + placeholder + ',' +
           'width:' + firstImage.width + ',' +
-          'height:' + firstImage.height + ',' +
+          'height:' + firstImage.height +
           '});');
     })
     .catch(err => loaderCallback(err));

--- a/test/jimp/build/__snapshots__/test.js.snap
+++ b/test/jimp/build/__snapshots__/test.js.snap
@@ -11,7 +11,6 @@ Object {
   ],
   "src": "foobar/cat-1000.d65e7ea.100.jpg",
   "srcSet": "foobar/cat-1000.d65e7ea.100.jpg",
-  "toString": [Function],
 }
 `;
 
@@ -28,7 +27,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.cf07671.250.jpg",
   "srcSet": "foobar/cat-1000.cf07671.250.jpg 250w",
-  "toString": [Function],
   "width": 250,
 }
 `;
@@ -51,7 +49,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w,foobar/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -69,7 +66,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -97,7 +93,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/img/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/img/cat-1000.9fca340.500.jpg 500w,foobar/img/cat-1000.e0adf4e.750.jpg 750w,foobar/img/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -125,7 +120,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/test/-500x450.jpg",
   "srcSet": "foobar/test/-500x450.jpg 500w,foobar/test/-750x675.jpg 750w,foobar/test/-1000x900.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -143,7 +137,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.b50e60c.100.jpg",
   "srcSet": "foobar/cat-1000.b50e60c.100.jpg 100w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -166,7 +159,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.b50e60c.100.jpg",
   "srcSet": "foobar/cat-1000.b50e60c.100.jpg 100w,foobar/cat-1000.4f9c9d6.200.jpg 200w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -189,7 +181,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-transparent.d88e8a0.500.png",
   "srcSet": "foobar/cat-transparent.d88e8a0.500.png 500w,foobar/cat-transparent.2f2f013.513.png 513w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -212,7 +203,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-transparent.19cbc92.500.jpg",
   "srcSet": "foobar/cat-transparent.19cbc92.500.jpg 500w,foobar/cat-transparent.2cd0b48.513.jpg 513w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -235,7 +225,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-transparent.19cbc92.500.jpg",
   "srcSet": "foobar/cat-transparent.19cbc92.500.jpg 500w,foobar/cat-transparent.2cd0b48.513.jpg 513w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -263,7 +252,6 @@ Object {
   "placeholder": undefined,
   "src": "public/cat-1000.9fca340.500.jpg",
   "srcSet": "public/cat-1000.9fca340.500.jpg 500w,public/cat-1000.e0adf4e.750.jpg 750w,public/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -281,7 +269,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -309,7 +296,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.f0784d9.600.jpg",
   "srcSet": "foobar/cat-1000.f0784d9.600.jpg 600w,foobar/cat-1000.2c580c0.700.jpg 700w,foobar/cat-1000.bbb4217.800.jpg 800w",
-  "toString": [Function],
   "width": 600,
 }
 `;
@@ -342,7 +328,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.b50e60c.100.jpg",
   "srcSet": "foobar/cat-1000.b50e60c.100.jpg 100w,foobar/cat-1000.cdade20.167.jpg 167w,foobar/cat-1000.d28adc0.234.jpg 234w,foobar/cat-1000.d2285e5.300.jpg 300w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -375,7 +360,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w,foobar/cat-1000.13f4f08.667.jpg 667w,foobar/cat-1000.394eeb3.834.jpg 834w,foobar/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -403,7 +387,6 @@ Object {
   "placeholder": Any<String>,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w,foobar/cat-1000.e0adf4e.750.jpg 750w,foobar/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -431,7 +414,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9fca340.500.jpg",
   "srcSet": "foobar/cat-1000.9fca340.500.jpg 500w,foobar/cat-1000.e0adf4e.750.jpg 750w,foobar/cat-1000.ad4b6c4.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;

--- a/test/sharp/build/__snapshots__/test.js.snap
+++ b/test/sharp/build/__snapshots__/test.js.snap
@@ -11,7 +11,6 @@ Object {
   ],
   "src": "foobar/cat-1000.d65e7ea.100.jpg",
   "srcSet": "foobar/cat-1000.d65e7ea.100.jpg",
-  "toString": [Function],
 }
 `;
 
@@ -28,7 +27,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.1165fd2.250.jpg",
   "srcSet": "foobar/cat-1000.1165fd2.250.jpg 250w",
-  "toString": [Function],
   "width": 250,
 }
 `;
@@ -51,7 +49,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w,foobar/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -69,7 +66,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -97,7 +93,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/img/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/img/cat-1000.c824bfd.500.jpg 500w,foobar/img/cat-1000.4a6828b.750.jpg 750w,foobar/img/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -125,7 +120,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/test/-500x450.jpg",
   "srcSet": "foobar/test/-500x450.jpg 500w,foobar/test/-750x675.jpg 750w,foobar/test/-1000x900.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -143,7 +137,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9f7cc5d.100.jpg",
   "srcSet": "foobar/cat-1000.9f7cc5d.100.jpg 100w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -166,7 +159,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9f7cc5d.100.jpg",
   "srcSet": "foobar/cat-1000.9f7cc5d.100.jpg 100w,foobar/cat-1000.fbbe9ae.200.jpg 200w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -189,7 +181,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-transparent.5974ff7.500.png",
   "srcSet": "foobar/cat-transparent.5974ff7.500.png 500w,foobar/cat-transparent.0103a6b.513.png 513w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -212,7 +203,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-transparent.5974ff7.500.png",
   "srcSet": "foobar/cat-transparent.5974ff7.500.png 500w,foobar/cat-transparent.0103a6b.513.png 513w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -240,7 +230,6 @@ Object {
   "placeholder": undefined,
   "src": "public/cat-1000.c824bfd.500.jpg",
   "srcSet": "public/cat-1000.c824bfd.500.jpg 500w,public/cat-1000.4a6828b.750.jpg 750w,public/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -258,7 +247,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -281,7 +269,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/avatar.f249d2b.32.webp",
   "srcSet": "foobar/avatar.f249d2b.32.webp 32w,foobar/avatar.5e4371f.64.webp 64w",
-  "toString": [Function],
   "width": 32,
 }
 `;
@@ -309,7 +296,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.2f4cc0f.600.jpg",
   "srcSet": "foobar/cat-1000.2f4cc0f.600.jpg 600w,foobar/cat-1000.9e4bee8.700.jpg 700w,foobar/cat-1000.124f1bd.800.jpg 800w",
-  "toString": [Function],
   "width": 600,
 }
 `;
@@ -342,7 +328,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.9f7cc5d.100.jpg",
   "srcSet": "foobar/cat-1000.9f7cc5d.100.jpg 100w,foobar/cat-1000.175351a.167.jpg 167w,foobar/cat-1000.f2a4f85.234.jpg 234w,foobar/cat-1000.78a20da.300.jpg 300w",
-  "toString": [Function],
   "width": 100,
 }
 `;
@@ -375,7 +360,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w,foobar/cat-1000.ebda48a.667.jpg 667w,foobar/cat-1000.8ded835.834.jpg 834w,foobar/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -403,7 +387,6 @@ Object {
   "placeholder": Any<String>,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w,foobar/cat-1000.4a6828b.750.jpg 750w,foobar/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;
@@ -431,7 +414,6 @@ Object {
   "placeholder": undefined,
   "src": "foobar/cat-1000.c824bfd.500.jpg",
   "srcSet": "foobar/cat-1000.c824bfd.500.jpg 500w,foobar/cat-1000.4a6828b.750.jpg 750w,foobar/cat-1000.1e07c81.1000.jpg 1000w",
-  "toString": [Function],
   "width": 500,
 }
 `;


### PR DESCRIPTION
Currently, `toString()` is injected when `{...image}`. It is inconvenient to remove this function from the image object using `pick` in a Lodash-like library. It can be fixed by hiding it into the prototype of the object.

```js
> img = Object.assign(Object.create({toString(){return this.src}}), {src: "foo.png", width: 100, height:200})
{ src: 'foo.png', width: 100, height: 200 }
> img.toString()
'foo.png'
> JSON.stringify(img)
'{"src":"foo.png","width":100,"height":200}'
> {...img}
{ src: 'foo.png', width: 100, height: 200 }
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign

